### PR TITLE
Fix blank consensus-item agreement crash

### DIFF
--- a/tests/test_consensus_empty_item.py
+++ b/tests/test_consensus_empty_item.py
@@ -1,0 +1,48 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("DATALOOP_PATH", os.path.join(os.getcwd(), ".dataloop_test"))
+
+from dtlpymetrics.evaluating.tasks import check_annotator_agreement, get_consensus_agreement
+
+
+class TestConsensusEmptyItem(unittest.TestCase):
+    def test_empty_user_confusion_scores_return_agreement(self):
+        self.assertTrue(check_annotator_agreement(scores=[], threshold=0.5))
+
+    @patch("dtlpymetrics.evaluating.tasks.cleanup_annots_by_score")
+    @patch("dtlpymetrics.evaluating.tasks.get_scores_by_annotator")
+    @patch("dtlpymetrics.evaluating.tasks.calc_task_item_score")
+    def test_keep_only_best_on_blank_consensus_item_returns_agreement(
+        self,
+        mock_calc_task_item_score,
+        mock_get_scores_by_annotator,
+        mock_cleanup_annots_by_score,
+    ):
+        mock_calc_task_item_score.return_value = []
+        mock_get_scores_by_annotator.return_value = {}
+
+        item = MagicMock()
+        item.id = "item-1"
+        task = MagicMock()
+        task.id = "task-1"
+        task.name = "consensus-task"
+
+        agreement = get_consensus_agreement(
+            item=item,
+            task=task,
+            agreement_config={
+                "agreement_threshold": 0.5,
+                "keep_only_best": True,
+                "fail_keep_all": True,
+            },
+        )
+
+        self.assertTrue(agreement)
+        mock_get_scores_by_annotator.assert_called_once()
+        mock_cleanup_annots_by_score.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fixes consensus agreement handling for blank consensus items (no USER_CONFUSION / no annotator-level scores)
- Prevents division-by-zero in agreement calculation and avoids keep-only-best cleanup when there are no annotator scores
- Adds a minimal regression test focused on this scenario

## Changes

**dtlpymetrics/evaluating/tasks.py**
- check_annotator_agreement: uses agreement-by-default when no USER_CONFUSION scores exist (single return style)
- get_consensus_agreement: guards keep-only-best flow when scores_by_annotator is empty (single return style)

**	ests/test_consensus_empty_item.py**
- Adds two focused tests for blank consensus behavior

## Verification

- **On this branch:** pytest tests/test_consensus_empty_item.py -q -> 2 passed
- **On main (same test file against main sources):** 2 failed with ZeroDivisionError in check_annotator_agreement (dtlpymetrics/evaluating/tasks.py:82)

## Notes

- This is a clean replacement PR based on the scope/description of #55, using a new branch with a single consolidated commit.