### PR TITLE
APPS-2053 Fix agreement threshold config key mismatch

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -105,7 +105,7 @@ class Scorer(dl.BaseServiceRunner):
 
         agreement_config = dict()
         node = context.node
-        agreement_config["agree_threshold"] = node.metadata.get("customNodeConfig", dict()).get("threshold", 0.5)
+        agreement_config["agreement_threshold"] = node.metadata.get("customNodeConfig", dict()).get("threshold", 0.5)
         agreement_config["keep_only_best"] = node.metadata.get("customNodeConfig", dict()).get(
             "consensus_pass_keep_best", False
         )
@@ -202,7 +202,7 @@ class Scorer(dl.BaseServiceRunner):
 
         agreement_config = dict()
         node = context.node
-        agreement_config["agree_threshold"] = node.metadata.get("customNodeConfig", dict()).get("threshold", 0.5)
+        agreement_config["agreement_threshold"] = node.metadata.get("customNodeConfig", dict()).get("threshold", 0.5)
         agreement_config["keep_annots"] = node.metadata.get("customNodeConfig", dict()).get("model_keep_annots", False)
 
         agreement = get_model_agreement(item=item, model=model, agreement_config=agreement_config)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -144,12 +144,12 @@ class TestRunner(unittest.TestCase):
         model = dl.models.get(model_id='67076a13859b460370cfd24a')
         item_agree = dl.items.get(item_id='67076a10fb04409b488e570c')
         agreement = get_model_agreement(
-            item=item_agree, model=model, agreement_config={'agree_threshold': 0.5, 'fail_keep_all': True}
+            item=item_agree, model=model, agreement_config={'agreement_threshold': 0.5, 'fail_keep_all': True}
         )
         self.assertTrue(agreement)
         item_disagree = dl.items.get(item_id='67076a10fb044082498e5709')
         disagreement = get_model_agreement(
-            item=item_disagree, model=model, agreement_config={'agree_threshold': 0.5, 'fail_keep_all': False}
+            item=item_disagree, model=model, agreement_config={'agreement_threshold': 0.5, 'fail_keep_all': False}
         )
         self.assertFalse(disagreement)
 


### PR DESCRIPTION
## Summary
- Fix key mismatch in runner config from `agree_threshold` to `agreement_threshold`
- Apply fix in both consensus and model agreement config paths
- Update test call sites to use the canonical key

## Validation
- `./.venv/Scripts/python -m pytest tests/test_consensus_empty_item.py -q`